### PR TITLE
Fixes: Fix dashboard time change and Window absolute time change

### DIFF
--- a/grafana-grafanatimeline-panel/src/components/ContextWindowSelector.tsx
+++ b/grafana-grafanatimeline-panel/src/components/ContextWindowSelector.tsx
@@ -10,6 +10,7 @@ interface Props {
   timelineRange: AbsoluteTimeRange;
   visibleRange: AbsoluteTimeRange;
   setVisibleRange: (r: AbsoluteTimeRange) => void;
+  setTimelineRange: (r: AbsoluteTimeRange) => void;
   onClose: () => void;
 }
 
@@ -29,6 +30,7 @@ export const ContextWindowSelector: React.FC<Props> = ({
   timelineRange,
   visibleRange,
   setVisibleRange,
+  setTimelineRange,
   onClose,
 }) => {
   const [fromText, setFromText] = useState<string>(dateTime(visibleRange.from).toISOString());
@@ -48,27 +50,7 @@ export const ContextWindowSelector: React.FC<Props> = ({
   }, [wrapperRef, onClose]);
 
   const applyWindow = (newRange: AbsoluteTimeRange) => {
-    const percentStart = (timelineRange.from - dashboardFrom) / (dashboardTo - dashboardFrom);
-    const percentEnd = (timelineRange.to - dashboardFrom) / (dashboardTo - dashboardFrom);
-
     setVisibleRange(newRange);
-
-    const u = uplotRef.current;
-    if (u) {
-      requestAnimationFrame(() => {
-        const brushFrom = newRange.from + percentStart * (newRange.to - newRange.from);
-        const brushTo = newRange.from + percentEnd * (newRange.to - newRange.from);
-        const left = u.valToPos(brushFrom, 'x');
-        const right = u.valToPos(brushTo, 'x');
-        u.setSelect({
-          left,
-          top: 0,
-          width: right - left,
-          height: u.bbox.height,
-        });
-      });
-    }
-
     onClose();
   };
 

--- a/grafana-grafanatimeline-panel/src/components/SimplePanel.tsx
+++ b/grafana-grafanatimeline-panel/src/components/SimplePanel.tsx
@@ -111,8 +111,10 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
     if (!u) {
       return;
     }
+
     const left = u.valToPos(timelineRange.from, 'x') + u.bbox.left;
     const right = u.valToPos(timelineRange.to, 'x') + u.bbox.left;
+
     setDragStyles({
       dragOverlayStyle: {
         position: 'absolute',
@@ -147,7 +149,7 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
 
   useEffect(() => {
     updateOverlay();
-  }, [updateOverlay, visibleRange]);
+  }, [updateOverlay, visibleRange, timelineRange.from, timelineRange.to]);
 
   const lastDashboardRange = useRef<AbsoluteTimeRange>({
     from: dashboardFrom,
@@ -156,12 +158,10 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
 
   useEffect(() => {
     const dashboardChanged =
-      lastDashboardRange.current.from !== dashboardFrom ||
-      lastDashboardRange.current.to !== dashboardTo;
+      lastDashboardRange.current.from !== dashboardFrom || lastDashboardRange.current.to !== dashboardTo;
 
     const timelineMatchesDashboard =
-      Math.abs(timelineRange.from - dashboardFrom) < 1000 &&
-      Math.abs(timelineRange.to - dashboardTo) < 1000;
+      Math.abs(timelineRange.from - dashboardFrom) < 1000 && Math.abs(timelineRange.to - dashboardTo) < 1000;
 
     if (dashboardChanged && !timelineMatchesDashboard) {
       setTimelineRange({ from: dashboardFrom, to: dashboardTo });
@@ -417,16 +417,31 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
                   timelineRange={timelineRange}
                   visibleRange={visibleRange}
                   setVisibleRange={(r) => {
-                    const visibleSpan = visibleRange.to - visibleRange.from;
-                    const relFrom = (timelineRange.from - visibleRange.from) / visibleSpan;
-                    const relTo = (timelineRange.to - visibleRange.from) / visibleSpan;
+                    const oldVisibleFrom = visibleRange.from;
+                    const oldVisibleTo = visibleRange.to;
+                    const visibleSpan = oldVisibleTo - oldVisibleFrom;
+
+                    const relFrom = (timelineRange.from - oldVisibleFrom) / visibleSpan;
+                    const relTo = (timelineRange.to - oldVisibleFrom) / visibleSpan;
+
                     const newVisibleFrom = r.from;
                     const newVisibleTo = r.to;
+
                     const newTimelineFrom = newVisibleFrom + relFrom * (newVisibleTo - newVisibleFrom);
                     const newTimelineTo = newVisibleFrom + relTo * (newVisibleTo - newVisibleFrom);
-                    setTimelineRange({ from: newTimelineFrom, to: newTimelineTo });
+
                     setVisibleRange(r, true);
+                    requestAnimationFrame(() => {
+                      suppressNextDashboardUpdate.current = true;
+                      setTimelineRange({ from: newTimelineFrom, to: newTimelineTo });
+
+                      const u = uplotRef.current;
+                      if (u) {
+                        u.setSelect({ left: 0, top: 0, width: 0, height: 0 });
+                      }
+                    });
                   }}
+                  setTimelineRange={setTimelineRange}
                   onClose={() => setAnchorEl(null)}
                 />
               </div>

--- a/grafana-grafanatimeline-panel/src/components/SimplePanel.tsx
+++ b/grafana-grafanatimeline-panel/src/components/SimplePanel.tsx
@@ -149,13 +149,25 @@ export const SimplePanel: React.FC<Props> = ({ options, data, width, height, fie
     updateOverlay();
   }, [updateOverlay, visibleRange]);
 
-  useEffect(() => {
-    const matchesDashboard =
-      Math.abs(timelineRange.from - dashboardFrom) < 1000 && Math.abs(timelineRange.to - dashboardTo) < 1000;
+  const lastDashboardRange = useRef<AbsoluteTimeRange>({
+    from: dashboardFrom,
+    to: dashboardTo,
+  });
 
-    if (matchesDashboard) {
+  useEffect(() => {
+    const dashboardChanged =
+      lastDashboardRange.current.from !== dashboardFrom ||
+      lastDashboardRange.current.to !== dashboardTo;
+
+    const timelineMatchesDashboard =
+      Math.abs(timelineRange.from - dashboardFrom) < 1000 &&
+      Math.abs(timelineRange.to - dashboardTo) < 1000;
+
+    if (dashboardChanged && !timelineMatchesDashboard) {
       setTimelineRange({ from: dashboardFrom, to: dashboardTo });
     }
+
+    lastDashboardRange.current = { from: dashboardFrom, to: dashboardTo };
   }, [dashboardFrom, dashboardTo, timelineRange.from, timelineRange.to]);
 
   const setVisibleRange = (range: AbsoluteTimeRange, suppressDashboardUpdate = false) => {


### PR DESCRIPTION
Before the absolute context window resize did not resize the brush when effectively zooming. Also changing the dashboard time or brushing in another panel didn't adjust the selection. Fixes for those.


https://github.com/user-attachments/assets/f8a860a6-7dee-401b-a97a-e3ece2d80ae8

